### PR TITLE
Using a colon after an unquoted mapping key

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,11 +14,11 @@ services:
     m6web.firewall.controller_listener:
         class: M6Web\Bundle\FirewallBundle\Controller\Listener
         tags:
-          - { name: kernel.event_listener, event: kernel.controller, method: onCoreController, priority:-255 }
+          - { name: kernel.event_listener, event: kernel.controller, method: onCoreController, priority: -255 }
         arguments: ["@annotation_reader", "@m6web.firewall.provider"]
 
     m6web.firewall.request_listener:
         class: M6Web\Bundle\FirewallBundle\EventListener\RequestListener
         tags:
-          - { name: kernel.event_listener, event: kernel.request, method: onRequest, priority:-255 }
+          - { name: kernel.event_listener, event: kernel.request, method: onRequest, priority: -255 }
         arguments: ["@m6web.firewall.provider"]


### PR DESCRIPTION
error: "Using a colon after an unquoted mapping key" that is not followed by an indication character (i.e. " ", ",", "[", "]", "{", "}") is deprecated

and make please a new release.