### PR TITLE
Change m6web_firewall.lists to a variable node

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -50,7 +50,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('lists')
                     ->useAttributeAsKey('name')
                     ->prototype('array')
-                        ->prototype('scalar')->cannotBeEmpty()->end()
+                        ->prototype('variable')->cannotBeEmpty()->end()
                     ->end()
                 ->end()
                 // Add pattern support

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,8 @@ class Configuration implements ConfigurationInterface
                                     if (!is_array($list) && !is_string($list)) {
                                         throw new InvalidConfigurationException('Invalid configuration for path "m6web_firewall.lists": lists are any depth arrays of string values');
                                     }
+                                    
+                                    return $list;
                                 })
                             ->end()
                             ->cannotBeEmpty()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,6 +3,7 @@ namespace M6Web\Bundle\FirewallBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder,
     Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * This is the class that validates and merges configuration from your app/config files
@@ -50,7 +51,16 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('lists')
                     ->useAttributeAsKey('name')
                     ->prototype('array')
-                        ->prototype('variable')->cannotBeEmpty()->end()
+                        ->prototype('variable')
+                            ->validate()
+                                ->always(function ($list) {
+                                    if (!is_array($list) && !is_string($list)) {
+                                        throw new InvalidConfigurationException('Invalid configuration for path "m6web_firewall.lists": lists are any depth arrays of string values');
+                                    }
+                                })
+                            ->end()
+                            ->cannotBeEmpty()
+                        ->end()
                     ->end()
                 ->end()
                 // Add pattern support


### PR DESCRIPTION
The extension has always been doing a deep flattening of the lists: https://github.com/M6Web/FirewallBundle/blob/074004033b1e98c6e0db6a6d3173edc609a232b6/DependencyInjection/M6WebFirewallExtension.php#L73  
but the way it is defined in Configuration allows only a single level list (this may be a sf4 thing because it works on our 3.x projects).

Changing the array to a variable prototype "restores" that old functionality.